### PR TITLE
Add vitest.config.mts to TypeScript include

### DIFF
--- a/apps/data-service/tsconfig.json
+++ b/apps/data-service/tsconfig.json
@@ -43,5 +43,5 @@
 		}
 	},
 	"exclude": ["test"],
-	"include": ["worker-configuration.d.ts", "service-bindings.d.ts", "src/**/*.ts"]
+	"include": ["worker-configuration.d.ts", "service-bindings.d.ts", "src/**/*.ts", "vitest.config.mts"]
 }


### PR DESCRIPTION
This patch resolves import errors that occur in inteliJ.